### PR TITLE
Fix multi-thread bug

### DIFF
--- a/app/src/main/java/com/killerwhale/memary/Activity/ARActivity.java
+++ b/app/src/main/java/com/killerwhale/memary/Activity/ARActivity.java
@@ -681,7 +681,6 @@ public class ARActivity extends ARBaseActivity
      * Designed to be executed on the GL Thread
      */
     private void clearDrawing() {
-        mStrokes.clear();
         mLineShaderRenderer.clear();
         showStrokeDependentUI();
     }


### PR DESCRIPTION
修复ar stroke上传时为空的问题。

Bug原因：多线程，mStrokes还未上传就被clear
Fix：删除clear语句